### PR TITLE
Bump Keycloak to v26 (jlab-v2)

### DIFF
--- a/container/keycloak/initdb.d/03_client.sh
+++ b/container/keycloak/initdb.d/03_client.sh
@@ -11,3 +11,6 @@ KEYCLOAK_SERVICE_ACCOUNT_ENABLED=true
 KEYCLOAK_REDIRECT_URIS='["https://localhost:8443/jam/*"]'
 KEYCLOAK_SECRET=yHi6W2raPmLvPXoxqMA7VWbLAA2WN0eB
 create_client
+
+# Wildfly Elytron client legacy adapter fix
+/opt/keycloak/bin/kcadm.sh update clients/${KEYCLOAK_CLIENT_NAME} -r $KEYCLOAK_REALM -s 'attributes."exclude.issuer.from.auth.response"=true'

--- a/deps.yaml
+++ b/deps.yaml
@@ -13,22 +13,18 @@ services:
       - ./container/oracle/initdb.d:/container-entrypoint-initdb.d
 
   keycloak:
-    image: jeffersonlab/keycloak:1.1.1
+    image: jeffersonlab/keycloak:2.0.1
     hostname: keycloak
     container_name: keycloak
     ports:
       - "8081:8080"
       - "9991:9990"
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
-      KEYCLOAK_FRONTEND_HOSTNAME: 'localhost'
-      KEYCLOAK_FRONTEND_PORT: '8081'
-      KEYCLOAK_SERVER_URL: 'http://keycloak:8080'
-      KEYCLOAK_HOME: '/opt/keycloak'
-      KEYCLOAK_REALM: 'test-realm'
-      KEYCLOAK_RESOURCE: 'jam'
-      KEYCLOAK_SECRET: 'yHi6W2raPmLvPXoxqMA7VWbLAA2WN0eB'
+      KC_FRONTEND_URL: 'http://localhost:8081/auth'
+      KC_BACKEND_URL: 'http://keycloak:8080/auth'
+      KC_HTTP_RELATIVE_PATH: '/auth'
+      KC_BOOTSTRAP_ADMIN_USERNAME: 'admin'
+      KC_BOOTSTRAP_ADMIN_PASSWORD: 'admin'
       TZ: 'America/New_York'
     volumes:
       - ./container/keycloak/initdb.d:/container-entrypoint-initdb.d


### PR DESCRIPTION
Runtime Upgrade Notes:
- Update wildfly standalone.xml `auth-server-url` to include `/auth`
- Update wildfly runtime env KEYCLOAK_FRONTEND_SERVER_URL and KEYCLOAK_BACKEND_SERVER_URL to include `/auth`

Code Changes:
- Update `deps.yaml` image and envs
- Update `03_client.sh` to tweak config to exclude `iss` (https://github.com/keycloak/keycloak/discussions/25684)